### PR TITLE
Silent install option for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 build/
 output/
+install.log
+uninstall.log
+*.un~
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 geosite-framework-build
 =======================
 
-Build script for GeositeFramework regions
+Build script and optional auto-installer for GeositeFramework regions.
 
 ### Usage Instructions
 #### For a single region
@@ -15,7 +15,7 @@ where:
 
 For example, to build the Gulf of Mexico region site, the command would look like this:
 
-``python build.py gulf-of-mexico-region``
+``python build.py gulfmex-region``
 
 That will assemble and build the gulfmex Coastal Resilience site in a workspace in the current directory.
 
@@ -26,6 +26,15 @@ which will build the ``azavea/TNC-LA-Freshwater`` region, assuming the region ha
 
 The executable installer will be in the ``[workspace]\output`` folder after the script runs successfully.
 
+#### Auto-installing a region
+If the build script is running on a machine with IIS, you can have it automatically remove old versions and install the recently built version in either the `production` or `development` environment.  The command is modified to add the additional `--dev` or `--prod` argument:
+
+`python build.py gulfmex-region --prod`
+
+The following convention applies for auto-installation:
+
+_The repo name contains the url and and install path and ends with `-region`.  For instance `gulfmex-region` will be installed to `C:\projects\TNC\gulfmex` at the url `gulfmex`._
+ 
 #### Using the build script to set up a development environment
 The same script leaves all of the intermediate code in the ``[workspace]\build`` directory so that plugin developers need only to create an IIS Application which points to ``[workspace]\build\GeositeFramework\src\GeositeFramework``.  This will be a working version of the region and all of its plugins, ready to be served.
 
@@ -44,8 +53,12 @@ You can then run the build script with the following:
 
 and it will build all regions listed in the conf file.  The output of all installers will still be in ``[workspace]\output``.  Note that the build process does *not* clear out the output directory, so you may also have old installers there.  The script *will* overwrite any files in ``output`` with newer versions.
 
+Building from a conf file can also auto install all regions with the same `--prod` or `--dev` commands:
+
+`python build.py ca.conf --config --dev`
+
 #### Errors and debugging the script
-##### Error deleteing ``build`` directory
+##### Error deleting ``build`` directory
 Occasionally, you may get an error that the ``build`` directory can not be deleted.  This can happen when IIS has a lock on a file coupled with a limitation with the python ``shutil.rmtree`` method on Windows.  Simply re-running the script will fix the issue.
 
 ##### Errors with the .NET compiler or NSIS Compiler
@@ -57,26 +70,8 @@ The build script makes certain assumptions about the structure and content of a 
   * ``region.json``: Main configuration file for a region site
   * ``proxy.config``: Proxy information for what URLs a region site can proxy HTTP requests for.
   * ``partners.html``: Optional.  Custom HTML for a "partners" popup.
-  * ``installer.nsi``: An NSIS Compiler script.
   * ``plugins.json``: A json config that specifies which remote plugins are need to be fetched for this region at build time.
   * ``plugins`` directory: A directory of named plugin directories that contain the specific configuration for a plugin, but not the plugin code itself.
-
-#### installer.nsi contents
-To allow the build script to compile an executable installer for the region, you must include an ``installer.nsi`` file.  The contents of the file should be similar to:
-
-```
-!DEFINE APP_NAME "TNC_CR_GulfOfMexico"
-
-!INCLUDE "GeositeInstall.nsh"
-
-!INSERTMACRO MakeGeositeInstaller "gulfmex" "TNC Coastal Resilience: Gulf of Mexico"
-
-```
-The ``APP_NAME`` will be the filename of the installer, as well as the key which the installer will use to determine if that region is already installed on a system, and offer to uninstall if so.
-
-The ``MakeGeositeInstaller`` macro line takes two arguments, the IIS URL that the app should be served from ("gulfmex" in this example) and the "Pretty Name" that will be presented on the installer dialog.
-
-You should only need to modify those three arguments to repurpose the install script for a new region.
 
 
 #### plugins.json contents

--- a/installer-scripts/installer.nsi.tmpl
+++ b/installer-scripts/installer.nsi.tmpl
@@ -1,0 +1,4 @@
+!DEFINE APP_NAME "tnc-ca-%(region)s"
+
+!INCLUDE "GeositeInstall.nsh"
+!INSERTMACRO MakeGeositeInstaller "%(region)s" "TNC Coastal Resilience: %(region)s"


### PR DESCRIPTION
* standardizes a naming convention of urls and install paths
* removes need for local installer.nsi file, it is now generated by the
script
* new commands to have the build script install to known dev/prod
environments

You should be able to pull this down and if you have IIS with a website called "Default Web Site" and one called "dev", run:

`python build.py gulfmex-region --prod`
`python build.py gulfmex-region --dev`

to install fully functional region sites.  A future commit will build off of the `dev` branch when installing to the dev environment
