### PR TITLE
Support specifying branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ To build a region in another github organization, an example could be:
 
 which will build the ``azavea/TNC-LA-Freshwater`` region, assuming the region has been updated to conform to the build script requirements (See: Setting up a Region Repo)
 
+If you want to use a different repository branch for the region, you can use the `--region-branch` argument. For example, to build a branch of the gulfmex region titled `configtest`, run `python build.py gulfmex-region --region-branch configtest`. You can also build a different branch of the framework using the `--framework-branch` argument. Both arguments can be used at the same time, but note that the `--prod` and `--dev` flags take precedent and will use the `master` and `development` branches, respectively, no matter what branches are specified by the other arguments. Also, at this time, neither of the branches can be specified when building sites from a config file.
+
 The executable installer will be in the ``[workspace]\output`` folder after the script runs successfully.
 
 #### Auto-installing a region


### PR DESCRIPTION
* Allow users to specify which branch to use for both the framework and the region being built. These options are not supported when using a config file.

**Testing instructions**
- Run with the `—framework_branch=layer-selector-v2`, and ensure the framework branch matches the provided name, and the region branch is `master`. The build script now outputs what branch it is attempting to check out.
- Run with only `—dev`, ensure both branches are `development` (The framework doesn’t have this, but it fails silently. This is the existing behavior.)
- Run with only `—prod`, ensure both branches are `master`
- Run with `region_branch=something` and `—dev`, and ensure both branches are `development`.
- Run with `framework_branch=layer-selector-v2` and `region_branch=development`, and ensure those branches are checked out.
- Run with `region_branch=something` and `—prod`, and ensure both branches are `master`.

Plugins should follow region branch in all cases.

Connects to CoastalResilienceNetwork/GeositeFramework#456