### PR TITLE
Include locales directory in installer

### DIFF
--- a/build.py
+++ b/build.py
@@ -211,7 +211,8 @@ def copy_region_files(workspace, region_dest):
     files = ['region.json', 'partners.html', 'Proxy.config']
     copy_files(files, src_dir)
 
-    directories = ['plugins', 'img', 'Views', 'methods', 'sims', 'xml', 'docs']
+    directories = ['plugins', 'img', 'Views', 'methods', 'sims', 'xml', 'docs',
+                   'locales']
     copy_dirs(directories, src_dir)
 
 

--- a/installer-scripts/GeositeInstall.nsh
+++ b/installer-scripts/GeositeInstall.nsh
@@ -2,7 +2,7 @@
 
 ;------------------------------------------------------------------------------
 ; Install a region-specific version of the Geosite Framework
-; 
+;
 ; NAME      - For naming files and URLs (should not contain spaces)
 ; NICE_NAME - For display and titles
 ;
@@ -38,8 +38,9 @@ Section "Web Files"
     File /r  ..\GeositeFramework\src\GeositeFramework\region.json
     File /nonfatal ..\GeositeFramework\src\GeositeFramework\partners.html
     File /r  ..\GeositeFramework\src\GeositeFramework\Scripts
-    
+
     ; Common but optional additional directories to copy
+    File /nonfatal /r ..\GeositeFramework\src\GeositeFramework\locales
     File /nonfatal /r ..\GeositeFramework\src\GeositeFramework\xml
     File /nonfatal /r ..\GeositeFramework\src\GeositeFramework\sims
     File /nonfatal /r ..\GeositeFramework\src\GeositeFramework\methods


### PR DESCRIPTION
New resources are provided in the core framework for a base translation,
which are now included in the installer output.  The directory will also
copy any region specific locales that may have special translations not
included in the framework.

Connects https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/630

Testing:
Build a test installer from this branch with the following command:
`python build.py nj-spanish-region --region-branch development --framework-branch develop`

This will produce an exe in `/output`.  Run that installer (you may have to put appropriate values in Website Name and App Pool Name, the defaults could be appropriate for your system).

In the install path (by default `c:\projects\tnc\nj-spanish`) check that the installed `app` path has the locales directory and files.