### PR TITLE
Limit git clone to current HEAD and remove git resources once they are no longer needed

### DIFF
--- a/build.py
+++ b/build.py
@@ -202,6 +202,13 @@ def fetch_plugins(plugins, branch=None):
         clone_repo(full_repo, target_dir, version, branch)
 
 
+def remove_git_dir(target_dir):
+    """ Remove git files from installed framework components """
+    parent_dir = os.getcwd()
+    args = ['rm', '-rf', ('%s\\%s\\.git') % (parent_dir, target_dir)]
+    execute(args)
+
+
 def copy_region_files(workspace, region_dest):
     """ Move region specific files into the framework base """
     src_dir = os.path.join(workspace, FRAMEWORK_REPO,
@@ -314,6 +321,9 @@ def clone_repo(full_repo, target_dir=None, version=None, branch=None):
         os.chdir(dest)
         execute(['git', 'reset', '--hard', version])
         os.chdir(original_dir)
+
+    # Clean-up. Git specific files are not needed for the installation
+    remove_git_dir(dest)
 
 
 def compile_project(root):

--- a/build.py
+++ b/build.py
@@ -283,6 +283,12 @@ def clone_repo(full_repo, target_dir=None, version=None, branch=None):
 
     repo_url = posixpath.join('https://github.com/' '%s.git' % full_repo)
     clone_args = ['git', 'clone', '--quiet', repo_url]
+
+    # Reduce the amount of git history that is cloned if the history is not
+    # needed.
+    if version is None:
+        clone_args.extend(['--depth', '1', '--no-single-branch'])
+
     if target_dir:
         clone_args.append(target_dir)
 


### PR DESCRIPTION
The filterSelect plugin until recently had a large number of image files checked into the repo. For whatever reason, this prevents IIS or NSIS from uninstalling the website properly, which leads to problems installing a region that includes that plugin (specifically, [connecticut-region](https://github.com/CoastalResilienceNetwork/connecticut-region)).

To fix this specific issue, the build tool now only clones the current HEAD. Even though the images were removed from the `filterSelect` plugin, they still exist in the git history. This fixes #13 and has the added benefit of making the install process slightly faster for some regions. The git resources for each plugin and the framework are also removed before the installer is built since they are not needed.

**Notes**
This does not fix the underlying issue of IIS or NSIS not being able to uninstall the current `connecticut-region` or a region that includes the `filterSelect` plugin, but it does allow it to succeed for now.

**Testing**
- Attempt to build the Connecticut region with the following command: `python build.py connecticut-region caseypt --dev`.
- The build process should be fairly quick and should not produce any errors.
- Verify that the plugin directories and the framework directory do not contain the `.git` folder.
- Verify that the site works locally.

Connects to #19 