### PR TITLE
Use windows command for deleting directories

### DIFF
--- a/build.py
+++ b/build.py
@@ -205,7 +205,7 @@ def fetch_plugins(plugins, branch=None):
 def remove_git_dir(target_dir):
     """ Remove git files from installed framework components """
     parent_dir = os.getcwd()
-    args = ['rm', '-rf', ('%s\\%s\\.git') % (parent_dir, target_dir)]
+    args = ['rmdir', '/s', '/q', ('%s\\%s\\.git') % (parent_dir, target_dir)]
     execute(args)
 
 


### PR DESCRIPTION
Replaces `rm` which is not typically available on Windows machines and was
causing errors to users without it.  New command, `rmdir` is a standard
windows command.

Connects #23 

