### PR TITLE
Make copying of font directory optional

### DIFF
--- a/installer-scripts/GeositeInstall.nsh
+++ b/installer-scripts/GeositeInstall.nsh
@@ -31,7 +31,7 @@ Section "Web Files"
     File /r  ..\GeositeFramework\src\GeositeFramework\css
     File /r  ..\GeositeFramework\src\GeositeFramework\img
     File /r  ..\GeositeFramework\src\GeositeFramework\js
-    File /r  ..\GeositeFramework\src\GeositeFramework\fonts
+    File /nonfatal /r  ..\GeositeFramework\src\GeositeFramework\fonts
     File /r  ..\GeositeFramework\src\GeositeFramework\plugins
     File /r  ..\GeositeFramework\src\GeositeFramework\sample_plugins
     File /r  ..\GeositeFramework\src\GeositeFramework\proxy.ashx


### PR DESCRIPTION
This directory will only exist for sites built on the prototype
framework branch.

**Testing**
To test this out, I built the framework from the `master` branch, which doesn't have the fonts folder, using this branch of the build tool for this job: http://jenkins01.internal.azavea.com/view/TNC/job/TNC%20NJ%20(prototype)/28/console

Site: http://lr01.internal.azavea.com:81/HUDSON_TNC_NJ_Prototype_28/

Connects to #27
