### PR TITLE
Allow region_branch to override --dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --region-branch [REGION_BRANCH]
-                        Region repo branch to use. Overridden by --dev and
-                        --prod options. Default=master
+                        Region repo branch to use. Default=master
   --framework-branch [FRAMEWORK_BRANCH]
                         Framework repo branch to use. Default=master
   --config              Source input was a configuration file for building
                         multiple regions at once
-  --dev                 Install this region to the development environment
+  --dev                 Install this region to the development environment,
+                        prefering `development` branch available, unless
+                        `--region_branch` is specified
   --prod                Install this region to the production environment
   --silent              Install this region without the prompt, mostly for
                         scripts
@@ -59,7 +60,7 @@ To build a region in another github organization, an example could be:
 
 which will build the ``azavea/TNC-LA-Freshwater`` region, assuming the region has been updated to conform to the build script requirements (See: Setting up a Region Repo)
 
-If you want to use a different repository branch for the region, you can use the `--region-branch` argument. For example, to build a branch of the gulfmex region titled `configtest`, run `python build.py gulfmex-region --region-branch configtest`. You can also build a different branch of the framework using the `--framework-branch` argument. Both arguments can be used at the same time, but note that the `--prod` and `--dev` flags take precedent and will use the `master` and `development` branches, respectively, no matter what branches are specified by the other arguments. Also, at this time, neither of the branches can be specified when building sites from a config file.
+If you want to use a different repository branch for the region, you can use the `--region-branch` argument. For example, to build a branch of the gulfmex region titled `configtest`, run `python build.py gulfmex-region --region-branch configtest`. This will override the region branch used if you also specify `--dev` `(development)` or `--prod` `(master)`. Also, at this time, neither of the branches can be specified when building sites from a config file.
 
 The executable installer will be in the ``[workspace]\output`` folder after the script runs successfully.
 

--- a/build.py
+++ b/build.py
@@ -53,8 +53,15 @@ def build_region(region, path, full_framework, framework_branch=None,
     # If installing to dev site, favor a branch named 'development' for the
     # region repo and any plugins, but don't fail if it doesn't exist
     # This is the convention used by TNC developers to introduce new features
-    region_branch = ('development' if do_install and not is_prod else
-                     region_branch)
+    if region_branch:
+        # An override was provided, use it
+        region_branch = region_branch
+    elif do_install and is_prod:
+        # Production build, use master (default)
+        region_branch = None
+    elif do_install and not is_prod:
+        # Dev site, with no region-branch override
+        region_branch = 'development'
 
     clone_repo(region, region_dest, branch=region_branch)
 
@@ -101,7 +108,7 @@ def install(region, path, is_prod=False):
     install_path = os.path.join(root_path, region)
 
     args = [exe_name,
-            '/S',
+	    '/S',
             '/WEBSITE_NAME=%s' % website,
             '/APP_URL=%s' % url,
             '/REINSTALL_OVER=true',


### PR DESCRIPTION
TNC uses `--dev` to auto install, but can't do so on region branches other
than 'development'.  Change the way that the options are applied so that
whenever specifying a region branch, that branch will be used. This is
implemented in an overly verbose way to avoid a confusing, nested
conditional.