### PR TITLE
Add version.txt for framework, region, and plugins

### DIFF
--- a/build.py
+++ b/build.py
@@ -142,7 +142,7 @@ def copy_region_files(workspace, region_dest):
                            'src', 'GeositeFramework')
     os.chdir(os.path.join(workspace, region_dest))
 
-    copy_files(['region.json'], src_dir)
+    copy_files(['region.json', 'version.txt'], src_dir)
 
     optional_files = ['partners.html', 'Proxy.config']
     copy_files(optional_files, src_dir, optional=True)
@@ -256,6 +256,15 @@ def clone_repo(full_repo, target_dir=None, version=None, branch=None):
         os.chdir(dest)
         execute(['git', 'reset', '--hard', version])
         os.chdir(original_dir)
+
+    # Write version.txt file to keep track of current git sha for repo
+    version_path = 'version.txt'
+    if os.path.exists(os.path.join(dest, 'src')):
+        # Put the version.txt file in the src dir if it exists
+        version_path = os.path.join('src', version_path)
+    os.chdir(dest)
+    execute(['git', 'rev-parse', '--short', 'HEAD', '>', version_path])
+    os.chdir(original_dir)
 
     # Clean-up. Git specific files are not needed anymore
     remove_git_dir(dest)

--- a/build.py
+++ b/build.py
@@ -112,8 +112,7 @@ def fetch_framework_and_plugins(region_dest, framework_branch=None,
 def fetch_plugins(plugins, branch=None):
     """ Clone each specified plugin at its optional version """
 
-    plugin_dir = os.path.join(FRAMEWORK_REPO, 'src',
-                              'GeositeFramework', 'plugins')
+    plugin_dir = os.path.join(FRAMEWORK_REPO, 'src', 'plugins')
 
     for plugin in plugins:
         # If org wasn't provided, assume CoastalResilienceNetwork
@@ -138,8 +137,7 @@ def remove_git_dir(target_dir):
 
 def copy_region_files(workspace, region_dest):
     """ Move region specific files into the framework base """
-    src_dir = os.path.join(workspace, FRAMEWORK_REPO,
-                           'src', 'GeositeFramework')
+    src_dir = os.path.join(workspace, FRAMEWORK_REPO, 'src')
     os.chdir(os.path.join(workspace, region_dest))
 
     copy_files(['region.json', 'version.txt'], src_dir)

--- a/build.py
+++ b/build.py
@@ -140,7 +140,8 @@ def copy_region_files(workspace, region_dest):
     src_dir = os.path.join(workspace, FRAMEWORK_REPO, 'src')
     os.chdir(os.path.join(workspace, region_dest))
 
-    copy_files(['region.json', 'version.txt'], src_dir)
+    copy_files(['region.json'], src_dir)
+    append_copy('version.txt', os.path.join(src_dir, 'version.txt'))
 
     optional_files = ['partners.html', 'Proxy.config']
     copy_files(optional_files, src_dir, optional=True)
@@ -191,6 +192,19 @@ def overwrite_copy(file_or_dir, dest, single_file=False, optional=False):
             print(msg)
         else:
             sys.exit(e)
+
+
+def append_copy(new_file, existing_file):
+    """ Append the contents of the destination file with the contents
+    of the new file.
+    """
+    if os.path.isfile(existing_file):
+        with open(existing_file, 'a') as ef:
+            with open(new_file) as nf:
+                for line in nf:
+                    ef.write(line)
+    else:
+        overwrite_copy(new_file, existing_file, single_file=True)
 
 
 def setup_workspace(path):


### PR DESCRIPTION
## Overview

In order to easily determine which version of the framework, region, and plugin(s) have been built and deployed, write a version.txt for each repo that contains the commit sha at build time.

## Notes

~~This will have to be updated as part of https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/1100. This is because of the planned folder structure change. And as a result of this, the root version.txt will have to be modified to contain both the commit sha of the region and the framework. I drafted some of this work [here](https://gist.github.com/caseycesari/e83d6ef75a7ec32eca08d3e2c23db1e9).~~ This has been updated.

## Testing instructions

- Run the build scripts, for example:

```
python build.py gulfmex-region --framework-branch cpc/static-clean-up
```
- Unzip the site artifact, and verify there is a version.txt in the root dir for the framework and region (there will be one file with two commit shas), and a file for each plugin. 
- Verify that despite the changes made in https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/1147, the site still functions correctly when run from a static server.

Connects to https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/1093